### PR TITLE
feat: add interactive hero panel state and styling

### DIFF
--- a/src/app/components/HeroContainer.tsx
+++ b/src/app/components/HeroContainer.tsx
@@ -6,9 +6,13 @@ import MainPanel from './MainPanel';
 import SecondaryPanels from './SecondaryPanels';
 import Marquee from './Marquee';
 
+type PanelKey = 'tech' | 'music' | 'travel';
+
 export default function HeroContainer() {
   const [showPreloader, setShowPreloader] = useState(true);
   const [showHero, setShowHero] = useState(false);
+  const [activePanel, setActivePanel] = useState<PanelKey>('tech');
+
   const handlePreloaderComplete = () => {
     setShowPreloader(false);
     setTimeout(() => {
@@ -16,13 +20,20 @@ export default function HeroContainer() {
     }, 100);
   };
 
+  const handleHeroMouseLeave = () => {
+    setActivePanel('tech');
+  };
+
   return (
     <>
       {showPreloader && <Preloader onComplete={handlePreloaderComplete} />}
-      
-      <div className={`h-screen grid grid-cols-[60%_40%] max-md:grid-cols-1 max-md:grid-rows-[60%_40%] relative overflow-hidden transition-opacity duration-1000 ${showHero ? 'opacity-100' : 'opacity-0'}`}>
-        <MainPanel />
-        <SecondaryPanels />
+
+      <div
+        className={`h-screen grid grid-cols-[60%_40%] max-md:grid-cols-1 max-md:grid-rows-[60%_40%] relative overflow-hidden transition-opacity duration-1000 ${showHero ? 'opacity-100' : 'opacity-0'}`}
+        onMouseLeave={handleHeroMouseLeave}
+      >
+        <MainPanel activePanel={activePanel} setActivePanel={setActivePanel} />
+        <SecondaryPanels activePanel={activePanel} setActivePanel={setActivePanel} />
         <Marquee />
       </div>
     </>

--- a/src/app/components/MainPanel.tsx
+++ b/src/app/components/MainPanel.tsx
@@ -1,11 +1,141 @@
 'use client';
 
+import type { Dispatch, SetStateAction } from 'react';
 import Panel from './ui/Panel';
+import { roboto } from '../fonts';
 
-export default function MainPanel() {
+type PanelKey = 'tech' | 'music' | 'travel';
+
+interface MainPanelProps {
+  activePanel: PanelKey;
+  setActivePanel: Dispatch<SetStateAction<PanelKey>>;
+}
+
+type HeroContent = {
+  label: string;
+  heroName: [string, string];
+  heroAccent: string;
+  tagline: string;
+  meta: string;
+  highlights: string[];
+  callout: string;
+  accentColor: string;
+  backgroundGradient: string;
+  backgroundAsset?: string;
+  overlayClass: string;
+};
+
+const heroContent: Record<PanelKey, HeroContent> = {
+  tech: {
+    label: 'WORLD 01 — TECH',
+    heroName: ['Ayaan', 'Javed'],
+    heroAccent: 'Creative Technologist',
+    tagline: 'Engineering immersive, resilient digital experiences for ambitious teams and curious users.',
+    meta: 'CURRENT FOCUS',
+    highlights: ['React 19', 'Next.js 15', 'Design Systems'],
+    callout: 'Building human-centered products that fuse design, motion, and engineering craft.',
+    accentColor: '#38bdf8',
+    backgroundGradient:
+      'linear-gradient(135deg, rgba(12, 74, 110, 0.65) 0%, rgba(15, 23, 42, 0.55) 50%, rgba(2, 6, 23, 0.85) 100%)',
+    overlayClass: 'hero-overlay--tech',
+    // Swap the gradient string above with: `linear-gradient(...), url('/your-tech-photo.jpg')` once final photography is ready.
+  },
+  music: {
+    label: 'WORLD 02 — MUSIC',
+    heroName: ['Ayaan', 'Javed'],
+    heroAccent: 'Electronic Musician',
+    tagline: 'Sculpting cinematic soundscapes with modular synths, Ableton experiments, and multi-sensory storytelling.',
+    meta: 'LATEST SETS',
+    highlights: ['Ableton Live', 'Modular Synth', 'Sound Design'],
+    callout: 'Composing audiovisual journeys that influence how I approach rhythm in product design.',
+    accentColor: '#f472b6',
+    backgroundGradient:
+      'linear-gradient(145deg, rgba(88, 28, 135, 0.75) 0%, rgba(46, 16, 101, 0.55) 45%, rgba(15, 11, 35, 0.9) 100%)',
+    overlayClass: 'hero-overlay--music',
+    // Consider pairing with a moody studio portrait bathed in magenta/blue lighting for extra depth.
+  },
+  travel: {
+    label: 'WORLD 03 — TRAVEL',
+    heroName: ['Ayaan', 'Javed'],
+    heroAccent: 'Curious Explorer',
+    tagline: 'Documenting journeys across continents to uncover the cultures, flavors, and stories that fuel new ideas.',
+    meta: 'RECENT JOURNEYS',
+    highlights: ['Tokyo', 'Lisbon', 'Jaipur', 'Singapore'],
+    callout: 'Capturing photography and narratives that translate into globally empathetic product thinking.',
+    accentColor: '#34d399',
+    backgroundGradient:
+      'linear-gradient(150deg, rgba(13, 148, 136, 0.6) 0%, rgba(6, 95, 70, 0.48) 42%, rgba(12, 74, 110, 0.82) 100%)',
+    overlayClass: 'hero-overlay--travel',
+    // A wide, cinematic landscape with generous negative space works beautifully for this panel.
+  },
+};
+
+export default function MainPanel({ activePanel }: MainPanelProps) {
+  const variant = heroContent[activePanel];
+  const shouldFillHeroName = activePanel !== 'tech';
+
+  const panelStyle = {
+    backgroundImage: variant.backgroundAsset
+      ? `${variant.backgroundGradient}, url(${variant.backgroundAsset})`
+      : variant.backgroundGradient,
+    backgroundSize: 'cover',
+    backgroundPosition: 'center',
+    backgroundRepeat: 'no-repeat',
+    backgroundColor: '#121212',
+  };
+
   return (
-    <Panel>
-      TECH
+    <Panel
+      className="hero-panel col-span-1 row-span-2 border-l-0 px-12 py-14 text-left hover:bg-transparent justify-end items-stretch max-xl:px-10 max-lg:px-8 max-lg:py-12 max-md:order-1 max-md:px-6 max-md:py-10"
+      style={panelStyle}
+    >
+      <div className={`hero-overlay ${variant.overlayClass}`} aria-hidden="true" />
+      <div
+        className="absolute inset-y-0 left-0 w-1/3 bg-gradient-to-r from-black/60 via-black/20 to-transparent"
+        aria-hidden="true"
+      />
+      <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(255,255,255,0.06),transparent_60%)] opacity-60" aria-hidden="true" />
+
+      <div className="relative z-10 flex h-full w-full flex-col justify-between">
+        <div className="flex items-center gap-4 text-[0.65rem] uppercase tracking-[0.5rem] text-primary-accent/60">
+          <span className="inline-block h-px w-12 bg-primary-accent/40" />
+          <span>{variant.label}</span>
+        </div>
+
+        <div className="flex flex-col gap-8">
+          <div className="space-y-6">
+            <div className="space-y-4">
+              <h1 className={`hero-name ${shouldFillHeroName ? 'hero-name--active' : ''}`}>
+                <span className="block">{variant.heroName[0]}</span>
+                <span className="block">{variant.heroName[1]}</span>
+              </h1>
+              <span
+                className={`hero-name-accent ${shouldFillHeroName ? 'hero-name-accent--active' : ''}`}
+                style={{ color: shouldFillHeroName ? variant.accentColor : undefined }}
+              >
+                {variant.heroAccent}
+              </span>
+            </div>
+            <p className={`${roboto.className} tagline`}>{variant.tagline}</p>
+          </div>
+
+          <div className="space-y-3">
+            <span className="secondary-panel-meta text-primary-accent/50">{variant.meta}</span>
+            <ul className="flex flex-wrap gap-3">
+              {variant.highlights.map((highlight) => (
+                <li
+                  key={highlight}
+                  className="rounded-full border border-white/10 px-4 py-2 text-[0.7rem] uppercase tracking-[0.35rem] text-primary-accent/70"
+                >
+                  {highlight}
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+
+        <p className={`${roboto.className} text-sm text-secondary-accent/70`}>{variant.callout}</p>
+      </div>
     </Panel>
   );
 }

--- a/src/app/components/SecondaryPanels.tsx
+++ b/src/app/components/SecondaryPanels.tsx
@@ -1,17 +1,131 @@
 'use client';
 
+import type { Dispatch, KeyboardEvent, SetStateAction } from 'react';
 import Panel from './ui/Panel';
+import { roboto } from '../fonts';
 
-export default function SecondaryPanels() {
+type PanelKey = 'tech' | 'music' | 'travel';
+
+type SecondaryPanelContent = {
+  key: Extract<PanelKey, 'music' | 'travel'>;
+  eyebrow: string;
+  title: string;
+  description: string;
+  metadata: string;
+  cue: string;
+  accentColor: string;
+  overlayGradient: string;
+};
+
+interface SecondaryPanelsProps {
+  activePanel: PanelKey;
+  setActivePanel: Dispatch<SetStateAction<PanelKey>>;
+}
+
+const secondaryPanels: SecondaryPanelContent[] = [
+  {
+    key: 'music',
+    eyebrow: 'WORLD 02 — MUSIC',
+    title: 'Sonic Worlds',
+    description: 'Live sets, modular synth experiments, and cinematic electronica that inform rhythm in my interfaces.',
+    metadata: 'Ableton Live · Analog Warmth · Beat Design',
+    cue: 'Hover / Tap to explore',
+    accentColor: '#f472b6',
+    overlayGradient: 'linear-gradient(150deg, rgba(88, 28, 135, 0.35) 0%, rgba(15, 15, 30, 0.9) 100%)',
+  },
+  {
+    key: 'travel',
+    eyebrow: 'WORLD 03 — TRAVEL',
+    title: 'Global Stories',
+    description: 'Photographing journeys across continents to gather cultural insights and broaden creative empathy.',
+    metadata: '28 Cities · 11 Countries · Countless Narratives',
+    cue: 'Hover / Tap to explore',
+    accentColor: '#34d399',
+    overlayGradient: 'linear-gradient(155deg, rgba(13, 148, 136, 0.35) 0%, rgba(8, 47, 73, 0.88) 100%)',
+  },
+];
+
+export default function SecondaryPanels({ activePanel, setActivePanel }: SecondaryPanelsProps) {
+  const handleTouch = (panelKey: SecondaryPanelContent['key']) => {
+    setActivePanel((previous) => (previous === panelKey ? 'tech' : panelKey));
+  };
+
+  const handleKeyboardActivate = (
+    panelKey: SecondaryPanelContent['key'],
+  ) => (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      handleTouch(panelKey);
+    }
+  };
+
   return (
-    <div className="grid grid-rows-2 h-full">
-      <Panel>
-        MUSIC
-      </Panel>
-      
-      <Panel>
-        TRAVEL
-      </Panel>
+    <div
+      className="grid grid-rows-2 h-full border-l border-[#282828] max-md:order-2"
+      onMouseLeave={() => setActivePanel('tech')}
+    >
+      {secondaryPanels.map((panel) => {
+        const isActive = activePanel === panel.key;
+
+        return (
+          <Panel
+            key={panel.key}
+            className={`relative cursor-pointer select-none items-start justify-between gap-6 px-10 py-10 text-left uppercase tracking-[0.3rem] transition-colors duration-500 hover:bg-[#1a1a1a]/70 max-lg:px-8 max-lg:py-8 max-md:px-6 max-md:py-6 ${
+              isActive ? 'text-primary-accent' : 'text-primary-accent/70'
+            }`}
+            role="button"
+            tabIndex={0}
+            aria-pressed={isActive}
+            aria-label={`${panel.title} panel`}
+            onMouseEnter={() => setActivePanel(panel.key)}
+            onFocus={() => setActivePanel(panel.key)}
+            onTouchStart={() => handleTouch(panel.key)}
+            onKeyDown={handleKeyboardActivate(panel.key)}
+            style={{ backgroundBlendMode: 'overlay' }}
+          >
+            <div
+              className={`absolute inset-0 transition-opacity duration-500 ease-in-out ${
+                isActive ? 'opacity-70' : 'opacity-0 group-hover:opacity-40'
+              }`}
+              style={{ background: panel.overlayGradient }}
+              aria-hidden="true"
+            />
+
+            <div className="relative z-10 flex h-full w-full flex-col justify-between">
+              <div className="flex flex-col gap-4">
+                <div className="flex items-center gap-3 text-[0.65rem] text-primary-accent/50">
+                  <span className="inline-block h-px w-8 bg-primary-accent/35" />
+                  <span>{panel.eyebrow}</span>
+                </div>
+                <div className="space-y-2">
+                  <h3 className={`text-3xl font-extrabold tracking-tight normal-case transition-colors duration-500 ${
+                    isActive ? 'text-primary-accent' : 'text-primary-accent/90'
+                  }`}>
+                    {panel.title}
+                  </h3>
+                  <p className={`${roboto.className} text-sm font-normal normal-case leading-relaxed text-secondary-accent/80`}>
+                    {panel.description}
+                  </p>
+                </div>
+              </div>
+
+              <div className="flex flex-col gap-4">
+                <div className="flex items-center gap-3 text-[0.65rem] text-primary-accent/55">
+                  <span
+                    className="inline-flex h-2 w-2 rounded-full"
+                    style={{ backgroundColor: panel.accentColor }}
+                    aria-hidden="true"
+                  />
+                  <span className="tracking-[0.35rem]">{panel.metadata}</span>
+                </div>
+                <span className="panel-cta text-primary-accent/40 transition-colors duration-500 group-hover:text-primary-accent/70">
+                  {panel.cue}
+                </span>
+              </div>
+            </div>
+          </Panel>
+        );
+      })}
     </div>
   );
 }

--- a/src/app/components/ui/Panel.tsx
+++ b/src/app/components/ui/Panel.tsx
@@ -1,21 +1,25 @@
 'use client';
 
-import { ReactNode } from 'react';
+import type { CSSProperties, HTMLAttributes, ReactNode } from 'react';
 import { montserrat } from '../../fonts';
 
-interface PanelProps {
+interface PanelProps extends HTMLAttributes<HTMLDivElement> {
   children: ReactNode;
   className?: string;
-  style?: React.CSSProperties;
+  style?: CSSProperties;
 }
 
-export default function Panel({ 
-  children, 
+export default function Panel({
+  children,
+  className,
+  style,
+  ...rest
 }: PanelProps) {
-  const panelStyles = `${montserrat.className} flex justify-center items-center bg-panel-bg font-extrabold transition-all duration-500 ease-in-out text-2xl opacity-60 hover:opacity-100 hover:bg-[#222222] border-l border-[#282828]`;
-  
+  const baseClassName = `${montserrat.className} group relative flex h-full w-full items-center justify-center overflow-hidden bg-panel-bg font-extrabold text-primary-accent/70 transition-all duration-500 ease-in-out hover:text-primary-accent hover:bg-[#1f1f1f] border-l border-[#282828]`;
+  const combinedClassName = [baseClassName, className].filter(Boolean).join(' ');
+
   return (
-    <div className={panelStyles}>
+    <div className={combinedClassName} style={style} {...rest}>
       {children}
     </div>
   );

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -23,43 +23,123 @@ body {
   .bg-dark-bg {
     background-color: var(--dark-bg);
   }
-  
+
   .bg-panel-bg {
     background-color: var(--panel-bg);
   }
-  
+
   .text-primary-accent {
     color: var(--primary-accent);
   }
-  
+
   .text-secondary-accent {
     color: var(--secondary-accent);
   }
-  
+
   .animate-marquee {
     animation: marquee 30s linear infinite;
   }
 }
 
-@keyframes marquee {
-  0% { 
-    transform: translateX(0); 
+@layer components {
+  .hero-panel {
+    position: relative;
   }
-  100% { 
-    transform: translateX(-50%); 
+
+  .hero-name {
+    font-size: clamp(3rem, 9vw, 8.5rem);
+    line-height: 0.85;
+    letter-spacing: -0.045em;
+    -webkit-text-stroke: 1.5px rgba(234, 234, 234, 0.45);
+    color: transparent;
+    transition: color var(--transition-speed) ease,
+      -webkit-text-stroke-color var(--transition-speed) ease,
+      text-shadow var(--transition-speed) ease;
+  }
+
+  .hero-name--active,
+  .hero-panel:hover .hero-name {
+    color: var(--primary-accent);
+    -webkit-text-stroke-color: transparent;
+    text-shadow: 0 0 45px rgba(255, 255, 255, 0.25);
+  }
+
+  .hero-name-accent {
+    display: inline-block;
+    letter-spacing: 0.75rem;
+    text-transform: uppercase;
+    font-size: clamp(1rem, 1.8vw, 1.4rem);
+    color: rgba(234, 234, 234, 0.3);
+    transition: color var(--transition-speed) ease;
+  }
+
+  .hero-name-accent--active {
+    color: var(--primary-accent);
+  }
+
+  .hero-overlay {
+    pointer-events: none;
+    position: absolute;
+    inset: 0;
+    transition: opacity var(--transition-speed) ease;
+  }
+
+  .hero-overlay--tech {
+    background: linear-gradient(140deg, rgba(15, 15, 15, 0.88) 0%, rgba(15, 15, 15, 0.35) 55%, rgba(6, 8, 18, 0.85) 100%);
+  }
+
+  .hero-overlay--music {
+    background: linear-gradient(160deg, rgba(12, 10, 26, 0.92) 0%, rgba(76, 29, 149, 0.55) 45%, rgba(12, 10, 26, 0.85) 100%);
+  }
+
+  .hero-overlay--travel {
+    background: linear-gradient(160deg, rgba(8, 47, 73, 0.9) 0%, rgba(13, 148, 136, 0.4) 48%, rgba(6, 95, 70, 0.82) 100%);
+  }
+
+  .tagline {
+    font-size: clamp(1.1rem, 1.6vw, 1.75rem);
+    line-height: 1.55;
+    max-width: 48ch;
+    color: rgba(234, 234, 234, 0.78);
+  }
+
+  .secondary-panel-meta {
+    letter-spacing: 0.35rem;
+    text-transform: uppercase;
+    font-size: 0.75rem;
+  }
+
+  .panel-cta {
+    letter-spacing: 0.3rem;
+    text-transform: uppercase;
+    font-size: 0.75rem;
+  }
+}
+
+@keyframes marquee {
+  0% {
+    transform: translateX(0);
+  }
+  100% {
+    transform: translateX(-50%);
   }
 }
 
 /* Mobile responsive text sizes */
 @media (max-width: 768px) {
   .hero-name {
-    font-size: 20vw !important;
+    font-size: 18vw !important;
   }
-  
+
+  .hero-name-accent {
+    font-size: 0.9rem !important;
+    letter-spacing: 0.5rem !important;
+  }
+
   .tagline {
-    font-size: 1.2rem !important;
+    font-size: 1rem !important;
   }
-  
+
   .marquee-text {
     font-size: 1rem !important;
   }


### PR DESCRIPTION
## Summary
- add shared activePanel state to hero container and wire it through the main/secondary panels
- rebuild the main hero panel with variant-aware imagery, typography and content layers
- enhance secondary panels with descriptive metadata, hover/touch handlers, and supporting gradients; extend CSS utilities for overlays and responsive hero text

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc36c8a0d48328b0e9430db4fadbae